### PR TITLE
Add option to produce output to a file for environments w/o mail

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Public version of the DNSSEC key rollover monitor and checker.
 
-The tool has been described in a paper released at the SATIN conference 
-<http://conferences.npl.co.uk/satin/>. See the paper at 
+The tool has been described in a paper released at the SATIN conference
+<http://conferences.npl.co.uk/satin/>. See the paper at
 <http://conferences.npl.co.uk/satin/papers/satin2011-Bortzmeyer.pdf>.
 
 
@@ -9,8 +9,9 @@ Basic instructions:
 
 1) sqlite3 dnssec.sqlite < create.sql
 
-2) Edit ~/.key-report.ini may be using key-report.ini.sample as a
-starting point.
+2) Edit ~/.key-report.ini; you can use key-report.ini.sample as a
+starting point. Set fileonly to a file which is appended to if
+you don't want to (or can't) send e-mail.
 
 3) while true:
    key-store-and-report.py $YOURDOMAIN $YOURSERVER

--- a/key-report.ini.sample
+++ b/key-report.ini.sample
@@ -3,3 +3,4 @@ mailserver: smtp.example.net
 prefix: DNSSEC Check of my zones
 maintainer: John.Foo@bar.example
 output: false
+fileonly: /path/to/file


### PR DESCRIPTION
Believe it or not, there are environments which don't allow use of mail (not even on localhost -- sigh). This patch allows to configure an output file (`fileonly`) which collects output similar to that which would have been sent by e-mail.
